### PR TITLE
bugfix: OLSRD writes nodename ip as 0.0.0.0 without neigbors

### DIFF
--- a/net/olsrd/Makefile
+++ b/net/olsrd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=olsrd
 PKG_VERSION:=0.6.7
-PKG_RELEASE:=bbhn-5
+PKG_RELEASE:=bbhn-6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://github.com/OLSR/olsrd/archive/v0.6.7

--- a/net/olsrd/Makefile
+++ b/net/olsrd/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=olsrd
 PKG_VERSION:=0.6.7
-PKG_RELEASE:=bbhn-4
+PKG_RELEASE:=bbhn-5
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://github.com/OLSR/olsrd/archive/v0.6.7

--- a/net/olsrd/patches/003_nameservice-fixup
+++ b/net/olsrd/patches/003_nameservice-fixup
@@ -10,7 +10,25 @@
    return 1;
  }
  
-@@ -825,11 +828,29 @@ decap_namemsg(struct name *from_packet,
+@@ -532,6 +535,17 @@ olsr_expire_write_file_timer(void *conte
+ {
+   write_file_timer = NULL;
+ 
++  /**
++   * Make sure our names are initalized
++   * so we don't write bogus IP's for local names.
++   */
++  if (!nameservice_configured) {
++    name_lazy_init();
++    if (!nameservice_configured) {
++      return;
++    }
++  }
++
+   write_resolv_file();             /* if forwarder_table_changed */
+   write_hosts_file();              /* if name_table_changed */
+   write_services_file(false); /* if service_table_changed */
+@@ -825,11 +839,29 @@ decap_namemsg(struct name *from_packet,
    // Instead only the validity time is set in insert_new_name_in_list function, which calls this one
    for (already_saved_name_entries = (*to); already_saved_name_entries != NULL;
         already_saved_name_entries = already_saved_name_entries->next) {

--- a/net/olsrd/patches/004_nameservice-tabfix
+++ b/net/olsrd/patches/004_nameservice-tabfix
@@ -1,0 +1,15 @@
+--- a/lib/nameservice/src/nameservice.c
++++ b/lib/nameservice/src/nameservice.c
+@@ -1244,10 +1244,10 @@
+ 
+       for (name = entry->names; name != NULL; name = name->next) {
+         struct ipaddr_str strbuf;
+-        OLSR_PRINTF(6, "%s\t", name->name);
++        OLSR_PRINTF(6, "%s", name->name);
+         OLSR_PRINTF(6, "\t#%s\n", olsr_ip_to_string(&strbuf, &entry->originator));
+ 
+-        fprintf(file, "%s\t", name->name);
++        fprintf(file, "%s", name->name);
+         fprintf(file, "\t#%s\n", olsr_ip_to_string(&strbuf, &entry->originator));
+       }
+     }


### PR DESCRIPTION
applied 9327f3c to hotfix-3.16.1.2 branch