### PR TITLE
Limit the positive sequence number difference which is considered valid, and prevent network storms

### DIFF
--- a/net/olsrd/patches/009-olsrd-seqnr.patch
+++ b/net/olsrd/patches/009-olsrd-seqnr.patch
@@ -1,0 +1,66 @@
+--- a/src/duplicate_set.c
++++ b/src/duplicate_set.c
+@@ -70,7 +70,7 @@ void olsr_cleanup_duplicates(union olsr_
+ 
+   entry = (struct dup_entry *)avl_find(&duplicate_set, orig);
+   if (entry != NULL) {
+-    entry->too_low_counter = DUP_MAX_TOO_LOW - 2;
++    entry->out_of_bounds_counter = DUP_MAX_OUT_OF_BOUNDS - 2;
+   }
+ }
+ 
+@@ -82,7 +82,7 @@ olsr_create_duplicate_entry(void *ip, ui
+   if (entry != NULL) {
+     memcpy(&entry->ip, ip, olsr_cnf->ip_version == AF_INET ? sizeof(entry->ip.v4) : sizeof(entry->ip.v6));
+     entry->seqnr = seqnr;
+-    entry->too_low_counter = 0;
++    entry->out_of_bounds_counter = 0;
+     entry->avl.key = &entry->ip;
+     entry->array = 0;
+   }
+@@ -160,12 +160,12 @@ olsr_message_is_duplicate(union olsr_mes
+   }
+ 
+   diff = olsr_seqno_diff(seqnr, entry->seqnr);
+-  if (diff < -31) {
+-    entry->too_low_counter++;
++  if (diff < -31 || diff > DUP_SEQNR_DIFF_HIGH_LIMIT) {
++    entry->out_of_bounds_counter++;
+ 
+-    // client did restart with a lower number ?
+-    if (entry->too_low_counter > DUP_MAX_TOO_LOW) {
+-      entry->too_low_counter = 0;
++    // client did restart with a too low or too high number ?
++    if (entry->out_of_bounds_counter > DUP_MAX_OUT_OF_BOUNDS) {
++      entry->out_of_bounds_counter = 0;
+       entry->seqnr = seqnr;
+       entry->array = 1;
+       return false;             /* start with a new sequence number, so NO duplicate */
+@@ -174,7 +174,7 @@ olsr_message_is_duplicate(union olsr_mes
+     return true;                /* duplicate ! */
+   }
+ 
+-  entry->too_low_counter = 0;
++  entry->out_of_bounds_counter = 0;
+   if (diff <= 0) {
+     uint32_t bitmask = 1u << ((uint32_t) (-diff));
+ 
+--- a/src/duplicate_set.h
++++ b/src/duplicate_set.h
+@@ -54,13 +54,14 @@
+ #define DUPLICATE_CLEANUP_INTERVAL 15000
+ #define DUPLICATE_CLEANUP_JITTER 25
+ #define DUPLICATE_VTIME 120000
+-#define DUP_MAX_TOO_LOW 16
++#define DUP_MAX_OUT_OF_BOUNDS 16
++#define DUP_SEQNR_DIFF_HIGH_LIMIT 0x2000
+ 
+ struct dup_entry {
+   struct avl_node avl;
+   union olsr_ip_addr ip;
+   uint16_t seqnr;
+-  uint16_t too_low_counter;
++  uint16_t out_of_bounds_counter;
+   uint32_t array;
+   uint32_t valid_until;
+ };


### PR DESCRIPTION
Based on the investigation and evidence presented here (https://docs.google.com/document/d/1OgURb2O36lWF518dKydJLBEEUTYt7khRTVzX8QChwqw/edit#heading=h.ae1tj35et5yr), I propose the following change to how OLSRD validates incoming message sequence numbers.  This is Mitigation 3 in the above document.

Currently OLSR considers a valid sequence number to be one which is between -31 and +32767 higher than the last (the small negative difference allows for a little out-of-order handling). Here we reduce this window to between -32 and 8191. This makes is impossible for a storm to form.

A storm forms when a set of valid sequence numbers exist in a packet such that each one is valid compared to the last in a circular fashion. These are created with OLSR restarts, and the odds off this happening can be defined as:

  ( ( t / n ) ^ ( k - 1 ) ) * factoral( k - 1 )

Where n is the sequence number range (65536), k the number of times the valid range divides into the number range, and t is the tolerance we have for picking a bad restart value. In the current system n=65536, k=2, and we'll let t=4, resulting in the probability of a restart causing a storm to be 1 in 16384 - not very high considering the number of nodes in the network. By changing the valid window to 8192 we have n=65536, k=8 and t=4, reducing the change of a storm to 1 in 60 trillion trillion ... much less likely.

One concern in reducing the valid positive sequence difference allowed is jitter - allowing for gaps between sequence number which are still valid. Measured jitter in the SF Mesh network (which is not the result of node resets) is in the low 100s, so this is not a problem.

This approach to the storm problem will result in a gradual improvement in network stability even if all nodes are not updated. Because a node with a smaller valid window will not pass storm packets, it will help to damped storms created by nodes even if other nodes have not yet been upgraded.

This change does not effect how a node resets it sequence numbers on restart. It may also be desirable to have a better behaved way to reset sequence numbers after restart. This does not address that.