### PR TITLE
Support large nameservice records

### DIFF
--- a/net/olsrd/patches/011-nameservice-bigmessage.patch
+++ b/net/olsrd/patches/011-nameservice-bigmessage.patch
@@ -1,0 +1,226 @@
+diff --git a/lib/nameservice/src/nameservice.c b/lib/nameservice/src/nameservice.c
+index 9dd6f3a5..e40d1151 100644
+--- a/lib/nameservice/src/nameservice.c
++++ b/lib/nameservice/src/nameservice.c
+@@ -614,6 +614,7 @@ olsr_namesvc_gen(void *foo __attribute__ ((unused)))
+   union olsr_message *message = (union olsr_message *)buffer;
+   struct interface_olsr *ifn;
+   int namesize;
++  int cursor, lastcursor;
+ 
+   if (!nameservice_configured) {
+     name_lazy_init();
+@@ -621,46 +622,69 @@ olsr_namesvc_gen(void *foo __attribute__ ((unused)))
+       return;
+     }
+   }
+-  /* fill message */
+-  if (olsr_cnf->ip_version == AF_INET) {
+-    /* IPv4 */
+-    message->v4.olsr_msgtype = MESSAGE_TYPE;
+-    message->v4.olsr_vtime = reltime_to_me(my_timeout * MSEC_PER_SEC);
+-    memcpy(&message->v4.originator, &olsr_cnf->main_addr, olsr_cnf->ipsize);
+-    message->v4.ttl = MAX_TTL;
+-    message->v4.hopcnt = 0;
+-    message->v4.seqno = htons(get_msg_seqno());
+-
+-    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message));
+-    namesize = namesize + sizeof(struct olsrmsg);
+-
+-    message->v4.olsr_msgsize = htons(namesize);
+-  } else {
+-    /* IPv6 */
+-    message->v6.olsr_msgtype = MESSAGE_TYPE;
+-    message->v6.olsr_vtime = reltime_to_me(my_timeout * MSEC_PER_SEC);
+-    memcpy(&message->v6.originator, &olsr_cnf->main_addr, olsr_cnf->ipsize);
+-    message->v6.ttl = MAX_TTL;
+-    message->v6.hopcnt = 0;
+-    message->v6.seqno = htons(get_msg_seqno());
+ 
+-    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v6.message));
+-    namesize = namesize + sizeof(struct olsrmsg6);
+-
+-    message->v6.olsr_msgsize = htons(namesize);
++  /* Calculate maxmimum packet size */
++  int maxsize = sizeof(buffer);
++  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
++    if (ifn->netbuf.maxsize < maxsize) {
++      maxsize = ifn->netbuf.maxsize;
++    }
+   }
+ 
+-  /* looping trough interfaces */
+-  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
+-    OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
++  /* Encapsulate name messages into a set of packets (keeping track of our position with a cursor)
++     While name messages can be large, the mtu limits how many we can send at a time. */
++  for (cursor = 0; cursor != -1; ) {
++    lastcursor = cursor;
++
++    /* fill message */
++    if (olsr_cnf->ip_version == AF_INET) {
++      /* IPv4 */
++      message->v4.olsr_msgtype = MESSAGE_TYPE;
++      message->v4.olsr_vtime = reltime_to_me(my_timeout * MSEC_PER_SEC);
++      memcpy(&message->v4.originator, &olsr_cnf->main_addr, olsr_cnf->ipsize);
++      message->v4.ttl = MAX_TTL;
++      message->v4.hopcnt = 0;
++      message->v4.seqno = htons(get_msg_seqno());
++
++      namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message), maxsize - sizeof(struct olsrmsg), &cursor);
++      namesize = namesize + sizeof(struct olsrmsg);
++
++      message->v4.olsr_msgsize = htons(namesize);
++    } else {
++      /* IPv6 */
++      message->v6.olsr_msgtype = MESSAGE_TYPE;
++      message->v6.olsr_vtime = reltime_to_me(my_timeout * MSEC_PER_SEC);
++      memcpy(&message->v6.originator, &olsr_cnf->main_addr, olsr_cnf->ipsize);
++      message->v6.ttl = MAX_TTL;
++      message->v6.hopcnt = 0;
++      message->v6.seqno = htons(get_msg_seqno());
++
++      namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v6.message), maxsize - sizeof(struct olsrmsg6), &cursor);
++      namesize = namesize + sizeof(struct olsrmsg6);
++
++      message->v6.olsr_msgsize = htons(namesize);
++    }
++
++    /* If we fail to make progress it means we've hit a message which is too big for our mtu.
++       Nothing we can do except skip it. */
++    if (cursor == lastcursor) {
++      cursor++;
++      continue;
++    }
++
++    /* looping trough interfaces */
++    for (ifn = ifnet; ifn; ifn = ifn->int_next) {
++      OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
+ 
+-    if (net_outbuffer_push(ifn, message, namesize) != namesize) {
+-      /* send data and try again */
+-      net_output(ifn);
+       if (net_outbuffer_push(ifn, message, namesize) != namesize) {
+-        OLSR_PRINTF(1, "NAME PLUGIN: could not send on interface: %s\n", ifn->int_name);
++        /* send data and try again */
++        net_output(ifn);
++        if (net_outbuffer_push(ifn, message, namesize) != namesize) {
++          OLSR_PRINTF(1, "NAME PLUGIN: could not send on interface: %s\n", ifn->int_name);
++        }
+       }
+     }
++
+   }
+ }
+ 
+@@ -732,32 +756,67 @@ olsr_parser(union olsr_message *m, struct interface_olsr *in_if __attribute__ ((
+  * Returns: the length of the message that was appended
+  */
+ int
+-encap_namemsg(struct namemsg *msg)
++encap_namemsg(struct namemsg *msg, int maxsize, int* cursor)
+ {
+   struct name_entry *my_name;
+ 
+   // add the hostname, service and forwarder entries after the namemsg header
+   char *pos = (char *)msg + sizeof(struct namemsg);
++  char* npos;
+   short i = 0;
+ 
++  msg->version = htons(NAME_PROTOCOL_VERSION);
++
+   // names
+   for (my_name = my_names; my_name != NULL; my_name = my_name->next) {
+-    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++    if (i >= *cursor) {
++      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++      if (npos - pos > maxsize) {
++        msg->nr_names = htons(i - *cursor);
++        *cursor = i;
++        return pos - (char *)msg;     //length
++      }
++      pos = npos;
++    }
+     i++;
+   }
+   // forwarders
+   for (my_name = my_forwarders; my_name != NULL; my_name = my_name->next) {
+-    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++    if (i >= *cursor) {
++      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++      if (npos - pos > maxsize) {
++        msg->nr_names = htons(i - *cursor);
++        *cursor = i;
++        return pos - (char *)msg;     //length
++      }
++      pos = npos;
++    }
+     i++;
+   }
+   // services
+   for (my_name = my_services; my_name != NULL; my_name = my_name->next) {
+-    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++    if (i >= *cursor) {
++      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++      if (npos - pos > maxsize) {
++        msg->nr_names = htons(i - *cursor);
++        *cursor = i;
++        return pos - (char *)msg;     //length
++      }
++      pos = npos;
++    }
+     i++;
+   }
+   // macs
+   for (my_name = my_macs; my_name != NULL; my_name = my_name->next) {
+-    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++    if (i >= *cursor) {
++      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
++      if (npos - pos > maxsize) {
++        msg->nr_names = htons(i - *cursor);
++        *cursor = i;
++        return pos - (char *)msg;     //length
++      }
++      pos = npos;
++    }
+     i++;
+   }
+   // latlon
+@@ -779,12 +838,21 @@ encap_namemsg(struct namemsg *msg)
+     e.type = NAME_LATLON;
+     e.name = s;
+     lookup_defhna_latlon(&e.ip);
+-    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), &e);
++    npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), &e);
++    if (npos - pos > maxsize) {
++      msg->nr_names = htons(i - *cursor);
++      *cursor = i;
++      return pos - (char *)msg;     //length
++    }
++    pos = npos;
+     i++;
+   }
++
+   // write the namemsg header with the number of announced entries and the protocol version
+-  msg->nr_names = htons(i);
+-  msg->version = htons(NAME_PROTOCOL_VERSION);
++  msg->nr_names = htons(i - *cursor);
++
++  /* Done */
++  *cursor = -1;
+ 
+   return pos - (char *)msg;     //length
+ }
+diff --git a/lib/nameservice/src/nameservice.h b/lib/nameservice/src/nameservice.h
+index b1ea1c90..941349c2 100644
+--- a/lib/nameservice/src/nameservice.h
++++ b/lib/nameservice/src/nameservice.h
+@@ -139,7 +139,7 @@ bool olsr_parser(union olsr_message *, struct interface_olsr *, union olsr_ip_ad
+ /* callback for periodic timer */
+ void olsr_namesvc_gen(void *);
+ 
+-int encap_namemsg(struct namemsg *);
++int encap_namemsg(struct namemsg *, int maxsize, int* cursor);
+ 
+ struct name_entry *add_name_to_list(struct name_entry *my_list, const char *value, int type, const union olsr_ip_addr *ip);
+ 

--- a/net/olsrd/patches/011-nameservice-bigmessage.patch
+++ b/net/olsrd/patches/011-nameservice-bigmessage.patch
@@ -2,7 +2,7 @@ diff --git a/lib/nameservice/src/nameservice.c b/lib/nameservice/src/nameservice
 index 9dd6f3a5..e40d1151 100644
 --- a/lib/nameservice/src/nameservice.c
 +++ b/lib/nameservice/src/nameservice.c
-@@ -614,6 +614,7 @@ olsr_namesvc_gen(void *foo __attribute__ ((unused)))
+@@ -610,6 +614,7 @@
    union olsr_message *message = (union olsr_message *)buffer;
    struct interface_olsr *ifn;
    int namesize;
@@ -10,7 +10,7 @@ index 9dd6f3a5..e40d1151 100644
  
    if (!nameservice_configured) {
      name_lazy_init();
-@@ -621,46 +622,69 @@ olsr_namesvc_gen(void *foo __attribute__ ((unused)))
+@@ -617,46 +622,69 @@
        return;
      }
    }
@@ -23,10 +23,17 @@ index 9dd6f3a5..e40d1151 100644
 -    message->v4.ttl = MAX_TTL;
 -    message->v4.hopcnt = 0;
 -    message->v4.seqno = htons(get_msg_seqno());
--
+ 
 -    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message));
 -    namesize = namesize + sizeof(struct olsrmsg);
--
++  /* Calculate maxmimum packet size */
++  int maxsize = sizeof(buffer);
++  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
++    if (ifn->netbuf.maxsize < maxsize) {
++      maxsize = ifn->netbuf.maxsize;
++    }
++  }
+ 
 -    message->v4.olsr_msgsize = htons(namesize);
 -  } else {
 -    /* IPv6 */
@@ -36,22 +43,6 @@ index 9dd6f3a5..e40d1151 100644
 -    message->v6.ttl = MAX_TTL;
 -    message->v6.hopcnt = 0;
 -    message->v6.seqno = htons(get_msg_seqno());
- 
--    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v6.message));
--    namesize = namesize + sizeof(struct olsrmsg6);
--
--    message->v6.olsr_msgsize = htons(namesize);
-+  /* Calculate maxmimum packet size */
-+  int maxsize = sizeof(buffer);
-+  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
-+    if (ifn->netbuf.maxsize < maxsize) {
-+      maxsize = ifn->netbuf.maxsize;
-+    }
-   }
- 
--  /* looping trough interfaces */
--  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
--    OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
 +  /* Encapsulate name messages into a set of packets (keeping track of our position with a cursor)
 +     While name messages can be large, the mtu limits how many we can send at a time. */
 +  for (cursor = 0; cursor != -1; ) {
@@ -66,10 +57,14 @@ index 9dd6f3a5..e40d1151 100644
 +      message->v4.ttl = MAX_TTL;
 +      message->v4.hopcnt = 0;
 +      message->v4.seqno = htons(get_msg_seqno());
-+
+ 
+-    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v6.message));
+-    namesize = namesize + sizeof(struct olsrmsg6);
 +      namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message), maxsize - sizeof(struct olsrmsg), &cursor);
 +      namesize = namesize + sizeof(struct olsrmsg);
-+
+ 
+-    message->v6.olsr_msgsize = htons(namesize);
+-  }
 +      message->v4.olsr_msgsize = htons(namesize);
 +    } else {
 +      /* IPv6 */
@@ -92,7 +87,10 @@ index 9dd6f3a5..e40d1151 100644
 +      cursor++;
 +      continue;
 +    }
-+
+ 
+-  /* looping trough interfaces */
+-  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
+-    OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
 +    /* looping trough interfaces */
 +    for (ifn = ifnet; ifn; ifn = ifn->int_next) {
 +      OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
@@ -113,7 +111,7 @@ index 9dd6f3a5..e40d1151 100644
    }
  }
  
-@@ -732,32 +756,67 @@ olsr_parser(union olsr_message *m, struct interface_olsr *in_if __attribute__ ((
+@@ -723,41 +756,68 @@
   * Returns: the length of the message that was appended
   */
  int
@@ -131,7 +129,9 @@ index 9dd6f3a5..e40d1151 100644
 +
    // names
    for (my_name = my_names; my_name != NULL; my_name = my_name->next) {
--    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-    if (is_nameentry_valid(my_name, NAME_HOST)) {
+-      pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
 +      if (npos - pos > maxsize) {
@@ -140,12 +140,14 @@ index 9dd6f3a5..e40d1151 100644
 +        return pos - (char *)msg;     //length
 +      }
 +      pos = npos;
-+    }
-     i++;
+     }
++    i++;
    }
    // forwarders
    for (my_name = my_forwarders; my_name != NULL; my_name = my_name->next) {
--    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-    if (is_nameentry_valid(my_name, NAME_FORWARDER)) {
+-      pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
 +      if (npos - pos > maxsize) {
@@ -154,12 +156,14 @@ index 9dd6f3a5..e40d1151 100644
 +        return pos - (char *)msg;     //length
 +      }
 +      pos = npos;
-+    }
-     i++;
+     }
++    i++;
    }
    // services
    for (my_name = my_services; my_name != NULL; my_name = my_name->next) {
--    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-    if (is_nameentry_valid(my_name, NAME_SERVICE)) {
+-      pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
 +      if (npos - pos > maxsize) {
@@ -168,12 +172,14 @@ index 9dd6f3a5..e40d1151 100644
 +        return pos - (char *)msg;     //length
 +      }
 +      pos = npos;
-+    }
-     i++;
+     }
++    i++;
    }
    // macs
    for (my_name = my_macs; my_name != NULL; my_name = my_name->next) {
--    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-    if (is_nameentry_valid(my_name, NAME_MACADDR)) {
+-      pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
+-      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
 +      if (npos - pos > maxsize) {
@@ -182,11 +188,12 @@ index 9dd6f3a5..e40d1151 100644
 +        return pos - (char *)msg;     //length
 +      }
 +      pos = npos;
-+    }
-     i++;
+     }
++    i++;
    }
    // latlon
-@@ -779,12 +838,21 @@ encap_namemsg(struct namemsg *msg)
+   if ('\0' != latlon_in_file[0]) {
+@@ -778,12 +838,21 @@
      e.type = NAME_LATLON;
      e.name = s;
      lookup_defhna_latlon(&e.ip);

--- a/net/olsrd/patches/011-nameservice-bigmessage.patch
+++ b/net/olsrd/patches/011-nameservice-bigmessage.patch
@@ -131,7 +131,7 @@
 -      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
-+      if (npos - pos > maxsize) {
++      if (npos - (char *)msg > maxsize) {
 +        msg->nr_names = htons(i - *cursor);
 +        *cursor = i;
 +        return pos - (char *)msg;     //length
@@ -147,7 +147,7 @@
 -      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
-+      if (npos - pos > maxsize) {
++      if (npos - (char *)msg > maxsize) {
 +        msg->nr_names = htons(i - *cursor);
 +        *cursor = i;
 +        return pos - (char *)msg;     //length
@@ -163,7 +163,7 @@
 -      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
-+      if (npos - pos > maxsize) {
++      if (npos - (char *)msg > maxsize) {
 +        msg->nr_names = htons(i - *cursor);
 +        *cursor = i;
 +        return pos - (char *)msg;     //length
@@ -179,7 +179,7 @@
 -      i++;
 +    if (i >= *cursor) {
 +      npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), my_name);
-+      if (npos - pos > maxsize) {
++      if (npos - (char *)msg > maxsize) {
 +        msg->nr_names = htons(i - *cursor);
 +        *cursor = i;
 +        return pos - (char *)msg;     //length
@@ -196,7 +196,7 @@
      lookup_defhna_latlon(&e.ip);
 -    pos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), &e);
 +    npos = create_packet((struct name *)ARM_NOWARN_ALIGN(pos), &e);
-+    if (npos - pos > maxsize) {
++    if (npos - (char *)msg > maxsize) {
 +      msg->nr_names = htons(i - *cursor);
 +      *cursor = i;
 +      return pos - (char *)msg;     //length
@@ -215,11 +215,9 @@
  
    return pos - (char *)msg;     //length
  }
-diff --git a/lib/nameservice/src/nameservice.h b/lib/nameservice/src/nameservice.h
-index b1ea1c90..941349c2 100644
 --- a/lib/nameservice/src/nameservice.h
 +++ b/lib/nameservice/src/nameservice.h
-@@ -139,7 +139,7 @@ bool olsr_parser(union olsr_message *, struct interface_olsr *, union olsr_ip_ad
+@@ -139,7 +139,7 @@
  /* callback for periodic timer */
  void olsr_namesvc_gen(void *);
  

--- a/net/olsrd/patches/011-nameservice-bigmessage.patch
+++ b/net/olsrd/patches/011-nameservice-bigmessage.patch
@@ -1,8 +1,6 @@
-diff --git a/lib/nameservice/src/nameservice.c b/lib/nameservice/src/nameservice.c
-index 9dd6f3a5..e40d1151 100644
---- a/lib/nameservice/src/nameservice.c
-+++ b/lib/nameservice/src/nameservice.c
-@@ -610,6 +614,7 @@
+--- nameservice.c.before	2022-01-12 20:04:17.436052808 -0800
++++ nameservice.c	2022-01-12 20:06:50.430326197 -0800
+@@ -624,6 +624,7 @@
    union olsr_message *message = (union olsr_message *)buffer;
    struct interface_olsr *ifn;
    int namesize;
@@ -10,7 +8,7 @@ index 9dd6f3a5..e40d1151 100644
  
    if (!nameservice_configured) {
      name_lazy_init();
-@@ -617,46 +622,69 @@
+@@ -631,46 +632,64 @@
        return;
      }
    }
@@ -26,17 +24,9 @@ index 9dd6f3a5..e40d1151 100644
  
 -    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message));
 -    namesize = namesize + sizeof(struct olsrmsg);
++  /* Limit maxmimum packet size */
 +  int maxsize = 1200;
- 
--    message->v4.olsr_msgsize = htons(namesize);
--  } else {
--    /* IPv6 */
--    message->v6.olsr_msgtype = MESSAGE_TYPE;
--    message->v6.olsr_vtime = reltime_to_me(my_timeout * MSEC_PER_SEC);
--    memcpy(&message->v6.originator, &olsr_cnf->main_addr, olsr_cnf->ipsize);
--    message->v6.ttl = MAX_TTL;
--    message->v6.hopcnt = 0;
--    message->v6.seqno = htons(get_msg_seqno());
++
 +  /* Encapsulate name messages into a set of packets (keeping track of our position with a cursor)
 +     While name messages can be large, the mtu limits how many we can send at a time. */
 +  for (cursor = 0; cursor != -1; ) {
@@ -51,14 +41,10 @@ index 9dd6f3a5..e40d1151 100644
 +      message->v4.ttl = MAX_TTL;
 +      message->v4.hopcnt = 0;
 +      message->v4.seqno = htons(get_msg_seqno());
- 
--    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v6.message));
--    namesize = namesize + sizeof(struct olsrmsg6);
++
 +      namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message), maxsize - sizeof(struct olsrmsg), &cursor);
 +      namesize = namesize + sizeof(struct olsrmsg);
- 
--    message->v6.olsr_msgsize = htons(namesize);
--  }
++
 +      message->v4.olsr_msgsize = htons(namesize);
 +    } else {
 +      /* IPv6 */
@@ -81,14 +67,31 @@ index 9dd6f3a5..e40d1151 100644
 +      cursor++;
 +      continue;
 +    }
- 
--  /* looping trough interfaces */
--  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
--    OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
++
 +    /* looping trough interfaces */
 +    for (ifn = ifnet; ifn; ifn = ifn->int_next) {
 +      OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
  
+-    message->v4.olsr_msgsize = htons(namesize);
+-  } else {
+-    /* IPv6 */
+-    message->v6.olsr_msgtype = MESSAGE_TYPE;
+-    message->v6.olsr_vtime = reltime_to_me(my_timeout * MSEC_PER_SEC);
+-    memcpy(&message->v6.originator, &olsr_cnf->main_addr, olsr_cnf->ipsize);
+-    message->v6.ttl = MAX_TTL;
+-    message->v6.hopcnt = 0;
+-    message->v6.seqno = htons(get_msg_seqno());
+-
+-    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v6.message));
+-    namesize = namesize + sizeof(struct olsrmsg6);
+-
+-    message->v6.olsr_msgsize = htons(namesize);
+-  }
+-
+-  /* looping trough interfaces */
+-  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
+-    OLSR_PRINTF(3, "NAME PLUGIN: Generating packet - [%s]\n", ifn->int_name);
+-
 -    if (net_outbuffer_push(ifn, message, namesize) != namesize) {
 -      /* send data and try again */
 -      net_output(ifn);
@@ -105,7 +108,7 @@ index 9dd6f3a5..e40d1151 100644
    }
  }
  
-@@ -723,41 +756,68 @@
+@@ -737,41 +756,68 @@
   * Returns: the length of the message that was appended
   */
  int
@@ -187,7 +190,7 @@ index 9dd6f3a5..e40d1151 100644
    }
    // latlon
    if ('\0' != latlon_in_file[0]) {
-@@ -778,12 +838,21 @@
+@@ -792,12 +838,21 @@
      e.type = NAME_LATLON;
      e.name = s;
      lookup_defhna_latlon(&e.ip);

--- a/net/olsrd/patches/011-nameservice-bigmessage.patch
+++ b/net/olsrd/patches/011-nameservice-bigmessage.patch
@@ -1,5 +1,5 @@
---- nameservice.c.before	2022-01-12 20:04:17.436052808 -0800
-+++ nameservice.c	2022-01-12 20:06:50.430326197 -0800
+--- a/lib/nameservice/src/nameservice.c
++++ b/lib/nameservice/src/nameservice.c
 @@ -624,6 +624,7 @@
    union olsr_message *message = (union olsr_message *)buffer;
    struct interface_olsr *ifn;

--- a/net/olsrd/patches/011-nameservice-bigmessage.patch
+++ b/net/olsrd/patches/011-nameservice-bigmessage.patch
@@ -26,13 +26,7 @@ index 9dd6f3a5..e40d1151 100644
  
 -    namesize = encap_namemsg((struct namemsg *)ARM_NOWARN_ALIGN(&message->v4.message));
 -    namesize = namesize + sizeof(struct olsrmsg);
-+  /* Calculate maxmimum packet size */
-+  int maxsize = sizeof(buffer);
-+  for (ifn = ifnet; ifn; ifn = ifn->int_next) {
-+    if (ifn->netbuf.maxsize < maxsize) {
-+      maxsize = ifn->netbuf.maxsize;
-+    }
-+  }
++  int maxsize = 1200;
  
 -    message->v4.olsr_msgsize = htons(namesize);
 -  } else {


### PR DESCRIPTION
The nameservice information in OLSR was limited by the size of the MTU used to send if. If the information was too big it was silently dumped. This change splits the namservice information into packets (no more than 1200 bytes) to send the information in pieces. Fortunately, the receiving code already handled nameservice information arriving in multiple packets. 

Because the change only effects the sender, and only senders with large nameservice information, this is compatible with the current network.