### PR TITLE
Non-blocking send

### DIFF
--- a/net/olsrd/patches/012-dotdraw-noblock-send.patch
+++ b/net/olsrd/patches/012-dotdraw-noblock-send.patch
@@ -1,0 +1,11 @@
+--- a/lib/dot_draw/src/olsrd_dot_draw.c
++++ b/lib/dot_draw/src/olsrd_dot_draw.c
+@@ -300,7 +300,7 @@ dotdraw_write_data(void *foo __attribute__ ((unused))) {
+   }
+ 
+   if (FD_ISSET(outbuffer_socket, &set)) {
+-    result = send(outbuffer_socket, outbuffer.buf, outbuffer.len, 0);
++    result = send(outbuffer_socket, outbuffer.buf, outbuffer.len, MSG_DONTWAIT);
+     if (result > 0)
+       abuf_pull(&outbuffer, result);
+ 


### PR DESCRIPTION
Make the sending of dot draw non-blocking.

Most of the code is already there. The **select** make sure we can write at least one byte to the socket. This means that the **send** won't error with EAGAIN. By adding the **MSG_DONTWAIT** flag to the **send** itself, the call will write as much to the socket buffer as it can, returning the actual number of bytes written, but not block. The rest of the code already handles partial buffer writes correctly.

```
  result = select(outbuffer_socket + 1, NULL, &set, NULL, &tv);
  if (result <= 0) {
    return;
  }

  if (FD_ISSET(outbuffer_socket, &set)) {
    result = send(outbuffer_socket, outbuffer.buf, outbuffer.len, MSG_DONTWAIT /* <-- FLAG ADDED HERE */);
    if (result > 0)
      abuf_pull(&outbuffer, result);

    if (result < 0) {
      /* close this socket and cleanup*/
```
