### PR TITLE
Reduce the time a tunnel tcp connection is open when the other end fails to respond

### DIFF
--- a/net/vtun/patches/102-vtun-retrylimit.patch
+++ b/net/vtun/patches/102-vtun-retrylimit.patch
@@ -1,0 +1,12 @@
+--- a/tunnel.c
++++ b/tunnel.c
+@@ -127,6 +127,9 @@ int tunnel(struct vtun_host *host)
+ 	   opt=1;
+ 	   setsockopt(host->rmt_fd,IPPROTO_TCP,TCP_NODELAY,&opt,sizeof(opt) );
+ 
++	   opt=60000;
++	   setsockopt(host->rmt_fd,IPPROTO_TCP,TCP_USER_TIMEOUT,&opt,sizeof(opt) );
++
+ 	   proto_write = tcp_write;
+ 	   proto_read  = tcp_read;
+ 


### PR DESCRIPTION
Reduce the time a tunnel tcp connection is open when the other end fails to respond. Currently the default is 30 minutes, but this change reduces that to 60 seconds.

Background: Back when I was looking at network storms last year, I would sometimes see data captures containing packets which was > 20 minutes older than everything else. For a long time this has stumped me because these networks just aren't big enough of slow enough for traffic to spend 20 minutes getting from place to place. So I've been looking at possible causes for this on and off since then. Then, while doing the tunnel porting work, I realized that our tcp tunnels have the potential to keep data buffered up if it loses contact with the other end; not if there is an orderly disconnection, but if it just disappears for a bit due to a problem between the tunnel server and client. If the connection issue between the two is resolved before the tcp connection times out (30 minutes is the default), traffic will flow again and anything buffered will be delivered. This can result in very old traffic being dumped into the network. This is not a good thing.

The TCP_USER_TIMEOUT option lets us set the timeout for a specific connection and has the kernel enforce it for us. I've chosen 60 seconds. If communication over a tunnel is taking more than 60 seconds (from a packet entering one and and arriving at the other), something is very wrong with it and the connection should be closed. VTUND will attempt to startup the connection again, but until a new tcp connection can be established, no traffic will be buffered for it, it won't become part of the network, and we don't risk delivering old traffic.

For more on this TCP option see https://man7.org/linux/man-pages/man7/tcp.7.html