### PR TITLE
Prevent tunnel traffic being sent over the mesh (unless explicitly enabled)

### DIFF
--- a/net/vtun/files/vtund.firewall
+++ b/net/vtun/files/vtund.firewall
@@ -4,4 +4,7 @@ vtunduciport=$(uci get vtun.options.port 2>/dev/null)
 vtundport=${vtunduciport:-5525}
 
 iptables -I zone_wan_input -p tcp -m tcp --dport $vtundport -j ACCEPT
-
+if [ "$(/sbin/uci -q get aredn.@tunnel[0].wanonly)" != "0" ]; then
+    iptables -I zone_wifi_output -p tcp -m tcp --dport $vtundport -j REJECT
+    iptables -I zone_dtdlink_output -p tcp -m tcp --dport $vtundport -j REJECT
+fi


### PR DESCRIPTION
By default, include firewall rules which prevent tunnels being established over the mesh (rather than over the wan). Can be disabled using an advanceconfig option.