### PR TITLE
AREDN exporter fixes

### DIFF
--- a/utils/prometheus-exporter/files/metrics/cpus.lua
+++ b/utils/prometheus-exporter/files/metrics/cpus.lua
@@ -38,11 +38,15 @@ for line in io.lines("/proc/loadavg")
 do
     local a1, a5, a15 = line:match("^(%S+) (%S+) (%S+)")
     if a1 then
-        print("# HELP node_load Load average over X minute")
-        print("# TYPE node_load gauge")
-        print('node_load{minutes="1"} ' .. a1)
-        print('node_load{minutes="5"} ' .. a5)
-        print('node_load{minutes="15"} ' .. a15)
+        print("# HELP node_load1 1m load average.")
+        print("# TYPE node_load1 gauge")
+        print('node_load1 ' .. a1)
+        print("# HELP node_load5 5m load average.")
+        print("# TYPE node_load5 gauge")
+        print('node_load5 ' .. a5)
+        print("# HELP node_load15 51m load average.")
+        print("# TYPE node_load15 gauge")
+        print('node_load15 ' .. a15)
         break
     end
 end

--- a/utils/prometheus-exporter/files/metrics/details.lua
+++ b/utils/prometheus-exporter/files/metrics/details.lua
@@ -42,7 +42,10 @@ os.capture = capture
 
 local lat, lon = info.getLatLon()
 
-print('node_details_basics{' ..
+print('# HELP node_aredn_info Labeled AREDN node information.' ..
+		'# TYPE node_aredn_info gauge')
+
+print('node_aredn_info{' ..
 		'board_id="' .. hardware_boardid() .. '"' ..
 		',description="' .. (info.getNodeDescription() or "") .. '"' ..
 		',firmware_version="' .. info.getFirmwareVersion() .. '"' ..
@@ -56,7 +59,10 @@ print('node_details_basics{' ..
 
 local dev = info.getMeshRadioDevice()
 if dev ~= "" then
-    print('node_details_meshrf{' ..
+	print('# HELP node_aredn_meshrf Labeled AREDN node mesh RF information.' ..
+		'# TYPE node_aredn_meshrf gauge')
+
+    print('node_aredn_meshrf{' ..
 		'band="' .. info.getBand(dev) .. '"' ..
         ',channel="' .. info.getChannel(dev) .. '"' ..
         ',chanbw="' .. info.getChannelBW(dev) .. '"' ..
@@ -67,3 +73,8 @@ if dev ~= "" then
 else
     print('node_details_meshrf 0')
 end
+
+print(	'# HELP node_uname_info MinimalLabeled system information as provided by the uname system call.' ..
+		'# TYPE node_uname_info gauge' ..
+		'node_uname_info{nodename="' .. (info.getNodeName() or "") .. '"} 1'
+	)

--- a/utils/prometheus-exporter/files/metrics/lqm.lua
+++ b/utils/prometheus-exporter/files/metrics/lqm.lua
@@ -47,6 +47,7 @@ if f then
         "distance",
         "exposed",
         "hidden",
+        "last_tx",
         "last_tx_total",
         "lat",
         "lon",

--- a/utils/prometheus-exporter/files/metrics/lqm.lua
+++ b/utils/prometheus-exporter/files/metrics/lqm.lua
@@ -47,7 +47,6 @@ if f then
         "distance",
         "exposed",
         "hidden",
-        "last_tx",
         "last_tx_total",
         "lat",
         "lon",

--- a/utils/prometheus-exporter/files/metrics/networks.lua
+++ b/utils/prometheus-exporter/files/metrics/networks.lua
@@ -68,7 +68,7 @@ local props = {
         local operstate = read_val(dev .. "/operstate")
         return 'node_network_info{address="' .. address .. '",broadcast="' .. broadcast .. '",device="' .. dev .. '",duplex="' .. duplex .. '",ifalias="' .. ifalias .. '",operstate="' .. operstate .. '"} 1'
     end },
-    { "mtu_bytes_total", "mtu" },
+    { "mtu_bytes", "mtu" },
     { "name_assign_type", "name_assign_type" },
     { "netdev_group", "netdev_group" },
     { "protocol_type", "type" },


### PR DESCRIPTION
I've added a bare minimal "node_uname_info" which brings us out of the box compatibility with Node Exporter Full: the most popular Grafana dashboard. https://grafana.com/grafana/dashboards/

While adding an HELP and TYPE block to the "node_details_*" metrics, I thought their name could be improved. Since these metrics are specific to AREDN I propose:
- node_aredn_info
- node_aredn_meshrf

Additionally, this PR contains 2 small fixes for a mistyped metric and a (what I believe is) a redundant gauge.

Test:
- I haven't tested this yet. I need to figure out how build the package first.

Notes:
- The indentation issues showing on the diff are due to a mix of whitespaces and tabs. I'm happy to fix this in a dedicated no-op commit later.
