### PR TITLE
Ignore del route errors if route doesnt exists

### DIFF
--- a/net/olsrd/patches/015-ignore-delroutes
+++ b/net/olsrd/patches/015-ignore-delroutes
@@ -1,0 +1,13 @@
+--- a/src/linux/kernel_routes_nl.c
++++ b/src/linux/kernel_routes_nl.c
+@@ -460,6 +460,10 @@
+           olsr_ip_prefix_to_string(dst), olsr_ip_to_string(&buf, &dst->prefix), if_ifwithindex_name(if_index),
+           strerror(errno), errno);
+     }
++    /* Failed to delete a route on a non-existant device - ignore the error so the route will be successfully remove from internal state */
++    if (!set && errno == 11 && if_ifwithindex(if_index) == NULL) {
++      err = 0;
++    }
+   }
+ 
+   return err;


### PR DESCRIPTION
Identify this style of error:
```
daemon.err olsrd[3259]: Delete route 10.66.200.56/0 via 0.0.0.0: Resource temporarily unavailable
daemon.info olsrd[3259]: Received netlink error code Invalid argument (-22)
daemon.err olsrd[3259]: . error: del route to 10.80.108.120/0.0.0.0 via 0.0.0.0 dev void onlink (Resource temporarily unavailable 11)
```
And remove the offending internal route state.

For some reason we are getting non-existent routes in the OLSR internal state which fail to be removed (because they dont exist). By default, OLSR keeps internal for each kernel route and will only remove the state when the kernel state is removed. But if they get out of sync, we end up looping trying to remove the same old internal route which never can be removed.

This change identifies the failure and instead reports the route was successfully removed so the internal state is correctly updated.