### PR TITLE
Fix MTU even for small MTU interfaces

### DIFF
--- a/net/olsrd/patches/016-fixed-mtu
+++ b/net/olsrd/patches/016-fixed-mtu
@@ -1,0 +1,15 @@
+--- a/src/unix/ifnet.c
++++ b/src/unix/ifnet.c
+@@ -664,11 +664,8 @@
+     ifs.int_metric = calculate_if_metric(ifr.ifr_name);
+   OLSR_PRINTF(1, "\tMetric: %d\n", ifs.int_metric);
+ 
+-  /* Get MTU */
+-  if (ioctl(olsr_cnf->ioctl_s, SIOCGIFMTU, &ifr) < 0)
+-    ifs.int_mtu = OLSR_DEFAULT_MTU;
+-  else
+-    ifs.int_mtu = ifr.ifr_mtu;
++  /* Set MTU */
++  ifs.int_mtu = OLSR_DEFAULT_MTU;
+ 
+   ifs.int_mtu -= (olsr_cnf->ip_version == AF_INET6) ? UDP_IPV6_HDRSIZE : UDP_IPV4_HDRSIZE;


### PR DESCRIPTION
OLSR selects the size of what it sends on an interface to match the specific interface MTU. This is fine when all the MTUs are the same. But if one is smaller, it can end up disposing of packets which dont fit. While I understand the efficiency argument for this, discarding valid data is a problem. So instead, we select a default (1500) MTU size (which is *mostly* what interfaces use) and let IP fragment anything sent which is too large.