### PR TITLE
Switch the Ubiquiti firmware

### DIFF
--- a/firmware/dd-wrt-ath10k-firmware/Makefile
+++ b/firmware/dd-wrt-ath10k-firmware/Makefile
@@ -69,4 +69,4 @@ endef
 
 $(eval $(call BuildPackage,ath10k-firmware-qca4019-ct))
 $(eval $(call BuildPackage,ath10k-firmware-qca9888-ct))
-$(eval $(call BuildPackage,ath10k-firmware-qca988x-ct))
+#$(eval $(call BuildPackage,ath10k-firmware-qca988x-ct))


### PR DESCRIPTION
Investigating problems with Ubiquiti devices not connecting. Switch to Ubiquiti firmware rather than third-party.