### PR TITLE
Incorrect quotes meant olsrd.conf file never actually read

### DIFF
--- a/net/olsrd/files/olsrd.hotplug.sh
+++ b/net/olsrd/files/olsrd.hotplug.sh
@@ -22,7 +22,7 @@ olsrd_list_configured_interfaces()
 olsrd_interface_already_in_config()
 {
 	# e.g.: 'Interface "eth0.1" "eth0.2" "wlan0"'
-	if grep -s ^'Interface ' '/var/etc/$OLSRD.conf' | grep -q "\"$DEVICE\""; then
+	if grep -s ^'Interface ' "/var/etc/$OLSRD.conf" | grep -q "\"$DEVICE\""; then
 		logger -t olsrd_hotplug -p daemon.debug "[OK] already_active: '$INTERFACE' => '$DEVICE'"
 		return 0
 	else


### PR DESCRIPTION
Use of single quote around /var/etc/$OLSRD.conf means the variable is never expanded. Need double quotes.