### PR TITLE
Disable converting OLSR broadcast packages to Unicast packets

### DIFF
--- a/net/olsrd/patches/019-broadcast-to-unicast.patch
+++ b/net/olsrd/patches/019-broadcast-to-unicast.patch
@@ -289,7 +289,7 @@ index 0f0e0d3d..7aeb123c 100644
    if (olsr_cnf->ip_version == AF_INET) {
      /* IP version 4 */
 -    if (olsr_sendto(ifp->send_socket, ifp->netbuf.buff, ifp->netbuf.pending, MSG_DONTROUTE, (struct sockaddr *)sin, sizeof(*sin)) <
-+    if (ifp->stations[0] != 0) {
++    if (0 && ifp->stations[0] != 0) {
 +      /* If we might have multiple stations (in wifi) we transform this broadcast into a group of unicasts */
 +      if (olsr_sendto_broadcast_to_unicast(ifp->olsr_raw_socket, ifp->netbuf.buff, ifp->netbuf.pending, ifp) < 0) {
 +        perror("olsr_sendto_broadcast_to_unicast(v4)");


### PR DESCRIPTION
Investigating performance issues in nightly. Disable this feature.