### PR TITLE
Cleaner shutdown of Babel

### DIFF
--- a/net/babel/files/babel.conf
+++ b/net/babel/files/babel.conf
@@ -13,7 +13,7 @@ import-table 254
 link-detect true
 daemonise false
 state-file /etc/state/babel-state
-shutdown-delay-ms 100
+shutdown-delay-ms 1000
 log-file /dev/stdout
 pid-file /var/run/babeld.pid
 #

--- a/net/babel/files/babel.init
+++ b/net/babel/files/babel.init
@@ -116,6 +116,10 @@ start_service() {
     procd_close_instance
 }
 
+stop_service() {
+    kill -1 $(cat /var/run/babeld.pid)
+}
+
 reload_service() {
     stop
     start

--- a/net/babel/files/babel.init
+++ b/net/babel/files/babel.init
@@ -118,6 +118,7 @@ start_service() {
 
 stop_service() {
     kill -1 $(cat /var/run/babeld.pid)
+    sleep 2
 }
 
 reload_service() {


### PR DESCRIPTION
A cleaner shutdown of Babel should result in a faster startup next time as we save important state.