### PR TITLE
Rework babel routing rules

### DIFF
--- a/net/babel/files/babel.init
+++ b/net/babel/files/babel.init
@@ -8,10 +8,12 @@ C=/var/etc/babel-active.conf
 
 build_active() {
     echo "router-id $(uci -c /etc/local/uci get hsmmmesh.settings.wifimac)" > ${C}
-    # Alway DtD so Babel is happy to have one interface
+    # Always dtdlink so Babel is happy to have one interface
     echo "interface br-dtdlink type wired" >> ${C}
     echo "interface br-dtdlink rxcost $(uci get babel.wired.rxcost)" >> ${C}
     echo "interface br-dtdlink split-horizon true" >> ${C}
+    # Configure each of the interfaces which are already up as we wont (usually) be dynamically
+    # told about them later. If we are informed again later, it's harmless.
     for p in /sys/class/net/*
     do
         if [ "$(cat ${p}/operstate)" != "down" ]; then
@@ -59,11 +61,20 @@ build_active() {
             esac
         fi
     done
+
     # Limit what we redistribute
     sn="$(uci get aredn.@supernode[0].enable)"
     gw="$(uci get aredn.@wan[0].olsrd_gw)"
+
+    # Never redistribute our WAN address
+    echo "redistribute local if br-wan deny" >> ${C}
+
     if [ "$sn" = "1" ]; then
-        me="$(uci -c /etc/config.mesh get setup.globals.wifi_ip)"
+        # Supernode redistribute a number of default routes; the default 10.X route
+        # as well as a set of 44.X routes. Note that we need 'proto 3' here otherwise
+        # these 'boot' routes wont match the rules. I *think* this is because they
+        # come from table 21 and are installed there as part of the boot process. It is
+        # *not* the same as 'local'.
         echo "import-table 21" >> ${C}
         echo "redistribute ip 10.0.0.0/8 proto 3 allow" >> ${C}
         if [ -f /etc/44net.conf ]; then
@@ -71,52 +82,61 @@ build_active() {
                 echo "redistribute ip ${line} proto 3 allow" >> ${C}
             done < /etc/44net.conf
         fi
-        echo "redistribute ip ${me}/32 eq 32 allow" >> ${C}
-        echo "out ip ${me}/32 eq 32 allow" >> ${C}
-        echo "out ip 10.0.0.0/8 eq 8 allow" >> ${C}
+        # Supernodes do not redistribute everything on their dtdlink, so we only
+        # allow our mesh default routes out that way and then deny everything else.
+        # We dont even allow our own IP out this way, instead relying on the 10.X route.
+        echo "out if br-dtdlink ip 10.0.0.0/8 eq 8 allow" >> ${C}
         if [ -f /etc/44net.conf ]; then
             while read line; do
                 prefix=$(/bin/ipcalc.sh ${line}|grep PREFIX|cut -d= -f2)
-                echo "out ip ${line} eq ${prefix} allow" >> ${C}
+                echo "out if br-dtdlink ip ${line} eq ${prefix} allow" >> ${C}
             done < /etc/44net.conf
         fi
         echo "out if br-dtdlink deny" >> ${C}
     else
+        # Redistribute any locally originating 10.X and 44.X routes.
         echo "redistribute ip 10.0.0.0/8 ge 24 allow" >> ${C}
-        if [ -f /etc/44net.conf ]; then
-            while read line; do
-                echo "redistribute ip ${line} allow" >> ${C}
-            done < /etc/44net.conf
-        fi
+        echo "redistribute ip 44.0.0.0/8 ge 24 allow" >> ${C}
     fi
+    # If we allow it, let our default route be redistributed so others on
+    # the mesh can use it.
     if [ "$gw" = "1" ]; then
         echo "redistribute ip 0.0.0.0/0 eq 0 allow" >> ${C}
     fi
+    # Dont redistribute tunnel endpoint addresses.
     if [ "$sn" = "1" ]; then
         echo "redistribute ip 172.30.0.0/16 deny" >> ${C}
     else
         echo "redistribute ip 172.31.0.0/16 deny" >> ${C}
     fi
-    echo "redistribute local if br-wan deny" >> ${C}
+    # Dont redistribute the LAN. The lan routes could be NAT addresses
+    # and we dont want to redistribute them, rather relying on earlier 10.X rules.
     echo "redistribute local if br-lan deny" >> ${C}
+
+    # Control where we install incoming routes. If we dont specify a
+    # table, and we dont deny, routes are installed in the table 20 (default)
     if [ "$sn" = "1" ]; then
+        # Dont install any of the default mesh route if this is a supernode
         echo "install ip 10.0.0.0/8 eq 8 deny" >> ${C}
+        # We deny any large routes which are part of our 44net configuration
+        # and only allow small 44 subnets to be routed between meshes.
         if [ -f /etc/44net.conf ]; then
             while read line; do
-                prefix=$(/bin/ipcalc.sh ${line}|grep PREFIX|cut -d= -f2)
-                echo "install ip ${line} eq ${prefix} deny" >> ${C}
+                echo "install ip ${line} le 23 deny" >> ${C}
             done < /etc/44net.conf
         fi
     else
+        # Install the mesh default route in table 21
         echo "install ip 10.0.0.0/8 eq 8 allow table 21" >> ${C}
-        if [ -f /etc/44net.conf ]; then
-            while read line; do
-                prefix=$(/bin/ipcalc.sh ${line}|grep PREFIX|cut -d= -f2)
-                echo "install ip ${line} eq ${prefix} allow table 21" >> ${C}
-            done < /etc/44net.conf
-        fi
+        echo "install ip 44.0.0.0/8 le 23 allow table 21" >> ${C}
     fi
+    # Install the internal default route in table 22
     echo "install ip 0.0.0.0/0 eq 0 allow table 22" >> ${C}
+    # Install all other 10.X and 44.X routes in table 20
+    echo "install ip 10.0.0.0/8 ge 24 allow table 20" >> ${C}
+    echo "install ip 44.0.0.0/8 ge 24 allow table 20" >> ${C}
+    # Drop everything else
+    echo "install ip 0.0.0.0/0 ge 0 deny" >> ${C}
 }
 
 cleanup() {


### PR DESCRIPTION
Improve and comment the babel rules configuration. This controls what routes are shared and installed on nodes and supernodes.