### PR TITLE
Adjust babels timings

### DIFF
--- a/net/babel/files/babel.conf
+++ b/net/babel/files/babel.conf
@@ -17,7 +17,7 @@ local-path-readwrite /var/run/babel.sock
 export-table 20
 import-table 28
 import-table 29
-link-detect true
+link-detect false
 daemonise false
 state-file /etc/state/babel-state
 shutdown-delay-ms 1000

--- a/net/babel/files/babel.mesh
+++ b/net/babel/files/babel.mesh
@@ -1,7 +1,7 @@
 config default 'default'
         option rxcost '96'
         option hello_interval '10'
-        option update_interval '300'
+        option update_interval '120'
         option smoothing_half_life 10
         option rtt_decay '42'
         option rtt_min '10'

--- a/net/babel/files/kernel.c
+++ b/net/babel/files/kernel.c
@@ -43,7 +43,7 @@ gettime(struct timeval *tv)
     int rc;
     static time_t offset = 0, previous = 0;
 
-#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0 && defined(CLOCK_MONOTONIC)
+//#if defined(_POSIX_TIMERS) && _POSIX_TIMERS > 0 && defined(CLOCK_MONOTONIC)
     static int have_posix_clocks = -1;
 
     if(UNLIKELY(have_posix_clocks < 0)) {
@@ -66,7 +66,7 @@ gettime(struct timeval *tv)
         tv->tv_usec = ts.tv_nsec / 1000;
         return rc;
     }
-#endif
+//#endif
 
     rc = gettimeofday(tv, NULL);
     if(rc < 0)


### PR DESCRIPTION
Occasionally we see Babel nodes disconnect from the network and then reconnect a few minutes later. As yet the root cause if not fully understood, but there are some fixed non-configurable timeouts in the code which we may be hitting by having our update time set so high; so bring it down to every 2 minutes from every 5.
Also, force the use of the monotonic clock which may not have been detected correctly on our builds.