### PR TITLE
Fix broken unicast optimization which will break the network in some cases.

### DIFF
--- a/net/babel/files/message.c
+++ b/net/babel/files/message.c
@@ -1801,13 +1801,8 @@ send_ihu(struct neighbour *neigh, struct interface *ifp)
     /* If we already have unicast data buffered for this peer, piggyback
        the IHU.  Only do that if RFC 6126 compatibility is disabled, since
        doing that might require sending an unscheduled unicast Hello. */
-    //unicast = !!(ifp->flags & IF_UNICAST) ||
-    //    (neigh->buf.len > 0 && !(ifp->flags & IF_RFC6126));
-
-    // Always unicast because these packets are directed at a specific neighbor and
-    // multicasting them is just pointlessly annoying everyone and forcing them to be
-    // mostly ignored.
-    unicast = 1;
+    unicast = !!(ifp->flags & IF_UNICAST) ||
+        (neigh->buf.len > 0 && !(ifp->flags & IF_RFC6126));
 
     if(!!(ifp->flags & IF_TIMESTAMPS) != 0 && neigh->hello_send_us &&
        /* Checks whether the RTT data is not too old to be sent. */


### PR DESCRIPTION
An optimization to send "I Hear You" messages as unicast rather than multicast, despite them being targeted at individual nodes, could result in them not being sent at all under some circumstances. Make sure we don't do that.