### PR TITLE
Avoid popen + lines bug in metrics lua code.

### DIFF
--- a/utils/prometheus-exporter/files/main
+++ b/utils/prometheus-exporter/files/main
@@ -38,6 +38,20 @@ package.path = package.path .. ";/usr/local/bin/?.lua"
 
 require("nixio")
 
+-- Patch to work around the EINTR bug with pipes and lines
+local lines = getmetatable(io.output()).lines
+getmetatable(io.output()).lines = function(self, ...)
+    local iter = lines(self, ...)
+    return function()
+        local ok, ret = pcall(iter)
+        if ok then
+            return ret
+        else
+            return nil
+        end
+    end
+end
+
 local gzip = (os.getenv("HTTP_ACCEPT_ENCODING") or ""):match("gzip")
 
 print "Content-type: text/plain; version=0.0.4\r"

--- a/utils/prometheus-exporter/files/metrics/arednlink.lua
+++ b/utils/prometheus-exporter/files/metrics/arednlink.lua
@@ -36,7 +36,9 @@
 
 local f = io.popen("/usr/local/bin/arednlink-dump")
 if f then
-    for line in f:lines()
+    local lines = f:read("*a")
+    f:close()
+    for line in lines:gmatch("[^\r\n]+")
     do
         local kind, stats = line:match("^statistics (%S+) (.+)$")
         if kind then
@@ -48,5 +50,4 @@ if f then
             end
         end
     end
-    f:close()
 end

--- a/utils/prometheus-exporter/files/metrics/babel.lua
+++ b/utils/prometheus-exporter/files/metrics/babel.lua
@@ -36,11 +36,13 @@
 
 local f = io.popen("/usr/sbin/babel-dump")
 if f then
+    local lines = f:read("*a")
+    f:close()
     local interfaces = 0;
     local neighbors = 0; 
     local routes = 0;
     local xroutes = 0;
-    for line in f:lines()
+    for line in lines:gmatch("[^\r\n]+")
     do
         if line:match("interface") then
             interfaces = interfaces + 1


### PR DESCRIPTION
A bug in lua can effect the use of popen and lines when used together under what seem like random circumstances. Patch against that here and also avoid using the combination where possible.

This does not affect the babel-only build.