### PR TITLE
Dont preserve babel state across reboots and upgrades.

### DIFF
--- a/net/babel/files/babel.conf
+++ b/net/babel/files/babel.conf
@@ -20,7 +20,7 @@ import-table 28
 import-table 29
 link-detect false
 daemonise false
-state-file /etc/state/babel-state
+state-file /var/run/babel-state
 shutdown-delay-ms 1000
 log-file /dev/stdout
 pid-file /var/run/babeld.pid


### PR DESCRIPTION
While keeping the babel state during babel restarts, which are quick, makes sense, hanging on to it across reboots and upgrades might cause problems. If the reboot is an attempt to fix network problems babel will just go back to where it was, and that's not useful.