### PR TITLE
Explicitly set timestamps on wifi interfaces.

### DIFF
--- a/net/babel/files/babel.hotplug
+++ b/net/babel/files/babel.hotplug
@@ -14,6 +14,7 @@ __END__
             if [ "${DEVICE}" != "br-nomesh" ]; then
                 socat - UNIX-CLIENT:${BABEL_PATH} <<__END__
 interface ${DEVICE} type wireless
+interface ${DEVICE} enable-timestamps true
 interface ${DEVICE} rxcost $(uci -q get babel.wireless.rxcost)
 __END__
             fi

--- a/net/babel/files/babel.init
+++ b/net/babel/files/babel.init
@@ -39,6 +39,7 @@ build_active() {
                         ;;
                     *)
                         echo "interface ${i} type wireless" >> ${C}
+                        echo "interface ${i} enable-timestamps true" >> ${C}
                         echo "interface ${i} rxcost $(uci -q get babel.wireless.rxcost)" >> ${C}
                         ;;
                 esac


### PR DESCRIPTION
For some reason they do not always inherit the defaults, so set it explicitly.