### PR TITLE
Explicitly add timestamps onto wifi connections.

### DIFF
--- a/net/babel/files/babel.hotplug
+++ b/net/babel/files/babel.hotplug
@@ -14,6 +14,7 @@ __END__
             if [ "${DEVICE}" != "br-nomesh" ]; then
                 socat - UNIX-CLIENT:${BABEL_PATH} <<__END__
 interface ${DEVICE} type wireless
+interface ${DEVICE} enable-timestamps true
 interface ${DEVICE} rxcost $(uci -q get babel.wireless.rxcost)
 __END__
             fi

--- a/net/babel/files/babel.init
+++ b/net/babel/files/babel.init
@@ -38,6 +38,7 @@ build_active() {
                     ;;
                 *)
                     echo "interface ${i} type wireless" >> ${C}
+                    echo "interface ${i} enable-timestamps true" >> ${C}
                     echo "interface ${i} rxcost $(uci -q get babel.wireless.rxcost)" >> ${C}
                     ;;
             esac


### PR DESCRIPTION
For some reason the default setting isn't always being applied to wifi so do it explicitly.