### PR TITLE
Dont queue packets for unresolved addresses

### DIFF
--- a/net/babel/files/kernel_netlink.c
+++ b/net/babel/files/kernel_netlink.c
@@ -784,6 +784,15 @@ kernel_setup_interface(int setup, const char *ifname, int ifindex)
                     ifname);
     }
 
+    /* Make sure we don't queue any unresolved packets.
+       Doing this just stuffs up the socket buffer with junk blocking everything. */
+    rc = snprintf(buf, 100, "/proc/sys/net/ipv6/neigh/%s/unres_qlen_bytes", ifname);
+    if(rc < 0 || rc >= 100)
+        return -1;
+    rc = write_proc(buf, 0);
+    if (rc < 0)
+        return -1;
+
     return 1;
 }
 


### PR DESCRIPTION
Dump IPv6 packets (so Babel) if we dont have an address resolved for the destination. This stops data backing up in the multicast socket blocking other packets and causing HELLO packet reception errors.