### PR TITLE
Increase the default babel buffer size to avoid network stalls.

### DIFF
--- a/net/babel/files/message.c
+++ b/net/babel/files/message.c
@@ -1010,6 +1010,7 @@ flushbuf(struct buffered *buf, struct interface *ifp)
         // all we can do is close it and reopen a new one.
         if(rc < 0 && errno == EAGAIN) {
             close(protocol_socket);
+            fprintf(stderr, "Protocol socket returned EAGAIN - reopening\n");
             sleep(1);
             // Create a new socket
             protocol_socket = babel_socket(protocol_port);

--- a/net/babel/files/net.c
+++ b/net/babel/files/net.c
@@ -53,6 +53,7 @@ babel_socket(int port)
     int saved_errno;
     int one = 1, zero = 0;
     const int ds = 0xc0;        /* CS6 - Network Control */
+    const int bufsize = 512 * 1024;
 
     s = socket(PF_INET6, SOCK_DGRAM, 0);
     if(s < 0)
@@ -91,6 +92,14 @@ babel_socket(int port)
         perror("Couldn't set traffic class");
 
     rc = setsockopt(s, IPPROTO_IPV6, IPV6_RECVPKTINFO, &one, sizeof(one));
+    if(rc < 0)
+        goto fail;
+
+    rc = setsockopt(s, SOL_SOCKET, SO_SNDBUFFORCE, &bufsize, sizeof(bufsize));
+    if(rc < 0)
+        goto fail;
+
+    rc = setsockopt(s, SOL_SOCKET, SO_RCVBUFFORCE, &bufsize, sizeof(bufsize));
     if(rc < 0)
         goto fail;
 


### PR DESCRIPTION
Increase the send/recv babel buffers to avoid network stalls when moving large routing tables around.
