### PR TITLE
EXPERIMENTAL: Use one babel socket per interface rather than just one global

### DIFF
--- a/net/babel/files/babel.mesh
+++ b/net/babel/files/babel.mesh
@@ -28,4 +28,4 @@ config xlink 'xlink'
 
 config supernode 'supernode'
         option update_interval '300'
-        option protocol_buffer_size '1048576'
+        option protocol_buffer_size '262144'

--- a/net/babel/files/babeld.h
+++ b/net/babel/files/babeld.h
@@ -104,7 +104,6 @@ extern int protocol_port, local_server_port;
 extern char *local_server_path;
 extern int local_server_write;
 extern unsigned char protocol_group[16];
-extern int protocol_socket;
 extern int kernel_socket;
 extern int kernel_check_interval;
 extern int max_request_hopcount;

--- a/net/babel/files/interface.c
+++ b/net/babel/files/interface.c
@@ -461,6 +461,12 @@ interface_updown(struct interface *ifp, int up)
         if(rc < 0) {
             goto fail;
         }
+        rc = setsockopt(ifp->protocol_socket, SOL_SOCKET, SO_BINDTODEVICE,
+                        ifp->name, strlen(ifp->name));
+        if(rc < 0) {
+            perror("setsockopt(SO_BINDTODEVICE)");
+            goto fail;
+        }
         memset(&mreq, 0, sizeof(mreq));
         memcpy(&mreq.ipv6mr_multiaddr, protocol_group, 16);
         mreq.ipv6mr_interface = ifp->ifindex;

--- a/net/babel/files/interface.c
+++ b/net/babel/files/interface.c
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 #define __APPLE_USE_RFC_3542
 #include <string.h>
+#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -43,6 +44,7 @@ THE SOFTWARE.
 #include "configuration.h"
 #include "local.h"
 #include "xroute.h"
+#include "net.h"
 
 #define MIN_MTU 512
 
@@ -268,6 +270,13 @@ interface_updown(struct interface *ifp, int up)
             goto fail;
         }
 
+        ifp->protocol_socket = babel_socket(protocol_port);
+        if (ifp->protocol_socket == -1) {
+            fprintf(stderr, "babel_socket(%s) failed.\n",
+                    ifp->name);
+            goto fail;
+        }
+
         rc = kernel_setup_interface(1, ifp->name, ifp->ifindex);
         if(rc < 0) {
             fprintf(stderr, "kernel_setup_interface(%s, %u) failed.\n",
@@ -455,7 +464,7 @@ interface_updown(struct interface *ifp, int up)
         memset(&mreq, 0, sizeof(mreq));
         memcpy(&mreq.ipv6mr_multiaddr, protocol_group, 16);
         mreq.ipv6mr_interface = ifp->ifindex;
-        rc = setsockopt(protocol_socket, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+        rc = setsockopt(ifp->protocol_socket, IPPROTO_IPV6, IPV6_JOIN_GROUP,
                         (char*)&mreq, sizeof(mreq));
         if(rc < 0) {
             perror("setsockopt(IPV6_JOIN_GROUP)");
@@ -492,11 +501,17 @@ interface_updown(struct interface *ifp, int up)
             memset(&mreq, 0, sizeof(mreq));
             memcpy(&mreq.ipv6mr_multiaddr, protocol_group, 16);
             mreq.ipv6mr_interface = ifp->ifindex;
-            rc = setsockopt(protocol_socket, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
-                            (char*)&mreq, sizeof(mreq));
-            if(rc < 0)
-                perror("setsockopt(IPV6_LEAVE_GROUP)");
+            if (ifp->protocol_socket > 0) {
+                rc = setsockopt(ifp->protocol_socket, IPPROTO_IPV6, IPV6_LEAVE_GROUP,
+                                (char*)&mreq, sizeof(mreq));
+                if(rc < 0)
+                    perror("setsockopt(IPV6_LEAVE_GROUP)");
+            }
             kernel_setup_interface(0, ifp->name, ifp->ifindex);
+        }
+        if (ifp->protocol_socket > 0) {
+            close(ifp->protocol_socket);
+            ifp->protocol_socket = 0;
         }
         if(ifp->ll)
             free(ifp->ll);

--- a/net/babel/files/interface.h
+++ b/net/babel/files/interface.h
@@ -110,6 +110,7 @@ struct buffered {
 struct interface {
     struct interface *next;
     struct interface_conf *conf;
+    int protocol_socket;
     unsigned int ifindex;
     unsigned short flags;
     unsigned short cost;

--- a/net/babel/files/message.c
+++ b/net/babel/files/message.c
@@ -1019,15 +1019,19 @@ flushbuf(struct buffered *buf, struct interface *ifp)
                 fprintf(stderr, "FATAL: Couldn't create new link local socket\n");
                 exit(1);
             }
+            rc = setsockopt(ifp->protocol_socket, SOL_SOCKET, SO_BINDTODEVICE,
+                        ifp->name, strlen(ifp->name));
+            if(rc < 0)
+                perror("setsockopt(SO_BINDTODEVICE)");
+
             struct ipv6_mreq mreq;
             memset(&mreq, 0, sizeof(mreq));
             memcpy(&mreq.ipv6mr_multiaddr, protocol_group, 16);
             mreq.ipv6mr_interface = ifp->ifindex;
-            int rc2 = setsockopt(ifp->protocol_socket, IPPROTO_IPV6, IPV6_JOIN_GROUP,
+            rc = setsockopt(ifp->protocol_socket, IPPROTO_IPV6, IPV6_JOIN_GROUP,
                             (char*)&mreq, sizeof(mreq));
-            if(rc2 < 0) {
+            if(rc < 0)
                 perror("setsockopt(IPV6_JOIN_GROUP)");
-            }
         }
     }
     VALGRIND_MAKE_MEM_UNDEFINED(buf->buf, buf->size);

--- a/net/babel/files/net.c
+++ b/net/babel/files/net.c
@@ -97,10 +97,6 @@ babel_socket(int port)
         goto fail;
 
     if (buffer_size > 0) {
-        rc = setsockopt(s, SOL_SOCKET, SO_SNDBUFFORCE, &buffer_size, sizeof(buffer_size));
-        if(rc < 0)
-            goto fail;
-
         rc = setsockopt(s, SOL_SOCKET, SO_RCVBUFFORCE, &buffer_size, sizeof(buffer_size));
         if(rc < 0)
             goto fail;


### PR DESCRIPTION
For nodes with many interfaces, notably big tunnel servers and supernodes, sharing a single socket between all these interfaces looks to be a bottleneck. When lots of nodes send messages in, they get stacked in a large incoming buffer. When the node sends a message out, these get stacked in a single outgoing buffer. For incoming this means messages at the end of the buffer can take a long time to process. For outgoing, message can get stuck waiting on earlier messages which can themselves be stuck waiting on slow interconnects. This is an experiment to see if giving each interface its own socket will remove these bottlenecks and result in a better, more consistently performing, system. The idea is that one slow interface will no longer impact all the others.