### PR TITLE
Calculate RTT times using median of recent measurements.

### DIFF
--- a/net/babel/files/neighbour.h
+++ b/net/babel/files/neighbour.h
@@ -45,6 +45,7 @@ struct neighbour {
     struct timeval echo_receive_time;
     unsigned int rtt;
     struct timeval rtt_time;
+    unsigned int rtt_set[8];
     int index_len; /* This is -1 when index is undefined */
     unsigned char index[32];
     struct interface *ifp;


### PR DESCRIPTION
The RTT calculator produces a few very big outliers which messes up the RTT running average calculation. Instead use a median calculation.