### PR TITLE
Babel optimizations

### DIFF
--- a/net/babel/files/Makefile
+++ b/net/babel/files/Makefile
@@ -1,7 +1,7 @@
 PREFIX = /usr/local
 MANDIR = $(PREFIX)/share/man
 
-CDEBUGFLAGS = -Os -g -Wall
+CDEBUGFLAGS = -O2 -Wall
 
 DEFINES = $(PLATFORM_DEFINES)
 

--- a/net/babel/files/interface.c
+++ b/net/babel/files/interface.c
@@ -83,7 +83,7 @@ add_interface(char *ifname, struct interface_conf *if_conf)
     if(ifp == NULL)
         return NULL;
 
-    strncpy(ifp->name, ifname, IF_NAMESIZE);
+    strncpy(ifp->name, ifname, IF_NAMESIZE - 1);
     ifp->conf = if_conf ? if_conf : default_interface_conf;
     ifp->hello_seqno = (random() & 0xFFFF);
 

--- a/net/babel/files/kernel_netlink.c
+++ b/net/babel/files/kernel_netlink.c
@@ -173,7 +173,7 @@ if_eui64(char *ifname, int ifindex, unsigned char *eui)
     s = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
     if(s < 0) return -1;
     memset(&ifr, 0, sizeof(ifr));
-    strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name));
+    strncpy(ifr.ifr_name, ifname, sizeof(ifr.ifr_name) - 1);
     rc = ioctl(s, SIOCGIFHWADDR, &ifr);
     if(rc < 0) {
         int saved_errno = errno;
@@ -804,7 +804,7 @@ kernel_interface_operational(const char *ifname, int ifindex)
     int flags = link_detect ? (IFF_UP | IFF_RUNNING) : IFF_UP;
 
     memset(&req, 0, sizeof(req));
-    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name));
+    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name) - 1);
     rc = ioctl(dgram_socket, SIOCGIFFLAGS, &req);
     if(rc < 0)
         return -1;
@@ -818,7 +818,7 @@ kernel_interface_ipv4(const char *ifname, int ifindex, unsigned char *addr_r)
     int rc;
 
     memset(&req, 0, sizeof(req));
-    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name));
+    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name) - 1);
     req.ifr_addr.sa_family = AF_INET;
     rc = ioctl(dgram_socket, SIOCGIFADDR, &req);
     if(rc < 0)
@@ -835,7 +835,7 @@ kernel_interface_mtu(const char *ifname, int ifindex)
     int rc;
 
     memset(&req, 0, sizeof(req));
-    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name));
+    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name) - 1);
     rc = ioctl(dgram_socket, SIOCGIFMTU, &req);
     if(rc < 0)
         return -1;
@@ -917,7 +917,7 @@ kernel_interface_wireless(const char *ifname, int ifindex)
         return -1;
 
     memset(&req, 0, sizeof(req));
-    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name));
+    strncpy(req.ifr_name, ifname, sizeof(req.ifr_name) - 1);
     rc = ioctl(dgram_socket, SIOCGIWNAME, &req);
     if(rc < 0) {
         if(errno == EOPNOTSUPP || errno == EINVAL)

--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -226,38 +226,47 @@ unsigned
 check_neighbours()
 {
     struct neighbour *neigh;
+    struct neighbour *nneigh;
     unsigned msecs = 50000;
+    int i;
 
     debugf("Checking neighbours.\n");
 
-    neigh = neighs;
-    while(neigh) {
-        int changed, rc;
-        changed = update_neighbour(neigh, &neigh->hello, 0, -1, 0);
-        rc = update_neighbour(neigh, &neigh->uhello, 1, -1, 0);
-        changed = changed || rc;
+    for(neigh = neighs; neigh; neigh = nneigh) {
+        nneigh = neigh->next;
+        update_neighbour(neigh, &neigh->hello, 0, -1, 0);
+        update_neighbour(neigh, &neigh->uhello, 1, -1, 0);
 
         if(neigh->hello.reach == 0 ||
            neigh->hello.time.tv_sec > now.tv_sec || /* clock stepped */
            timeval_minus_msec(&now, &neigh->hello.time) > 300000) {
-            struct neighbour *old = neigh;
-            neigh = neigh->next;
-            flush_neighbour(old);
-            continue;
+            flush_neighbour(neigh);
         }
+        else {
+            reset_txcost(neigh);
+            /* Temp cost to avoid recalculating later */
+            neigh->temp_cost = neighbour_cost(neigh);
 
-        rc = reset_txcost(neigh);
-        changed = changed || rc;
+            if(neigh->hello.interval > 0)
+                msecs = MIN(msecs, neigh->hello.interval * 10);
+            if(neigh->uhello.interval > 0)
+                msecs = MIN(msecs, neigh->uhello.interval * 10);
+            if(neigh->ihu_interval > 0)
+                msecs = MIN(msecs, neigh->ihu_interval * 10);
+        }
+    }
 
-        update_neighbour_metric(neigh, changed);
+    /* Now we have the neighbours up-to-date we can update the route metrics */
+    for(i = 0; i < route_slots; i++) {
+        struct babel_route *r;
+        for(r = routes[i]; r; r = r->next) {
+            struct neighbour *n = r->neigh;
+            update_route_metric(r, n, n->temp_cost);
+        }
+    }
 
-        if(neigh->hello.interval > 0)
-            msecs = MIN(msecs, neigh->hello.interval * 10);
-        if(neigh->uhello.interval > 0)
-            msecs = MIN(msecs, neigh->uhello.interval * 10);
-        if(neigh->ihu_interval > 0)
-            msecs = MIN(msecs, neigh->ihu_interval * 10);
-        neigh = neigh->next;
+    for(neigh = neighs; neigh; neigh = neigh->next) {
+        local_notify_neighbour(neigh, LOCAL_CHANGE);
     }
 
     return msecs;

--- a/net/babel/files/neighbour.h
+++ b/net/babel/files/neighbour.h
@@ -50,6 +50,7 @@ struct neighbour {
     unsigned char index[32];
     struct interface *ifp;
     struct buffered buf;
+    unsigned int temp_cost; /* Temporarily holds the current cost */
 };
 
 extern struct neighbour *neighs;

--- a/net/babel/files/net.c
+++ b/net/babel/files/net.c
@@ -324,7 +324,7 @@ unix_server_socket(const char *path)
 
     memset(&sun, 0, sizeof(sun));
     sun.sun_family = AF_UNIX;
-    strncpy(sun.sun_path, path, sizeof(sun.sun_path));
+    strncpy(sun.sun_path, path, sizeof(sun.sun_path) - 1);
     rc = bind(s, (struct sockaddr *)&sun, sizeof(sun));
     if(rc < 0)
         goto fail;

--- a/net/babel/files/route.c
+++ b/net/babel/files/route.c
@@ -270,9 +270,9 @@ flush_route(struct babel_route *route)
         else if(max_route_slots > 8 && route_slots < max_route_slots / 4)
             resize_route_table(max_route_slots / 2);
     } else {
-        struct babel_route *r = routes[i];
-        while(r->next != route)
-            r = r->next;
+        struct babel_route *r;
+        for(r = routes[i]; r->next != route; r = r->next)
+            ;
         r->next = route->next;
         route->next = NULL;
         destroy_route(route);
@@ -428,9 +428,9 @@ move_installed_route(struct babel_route *route, int i)
     assert(route->installed);
 
     if(route != routes[i]) {
-        struct babel_route *r = routes[i];
-        while(r->next != route)
-            r = r->next;
+        struct babel_route *r;
+        for(r = routes[i]; r->next != route; r = r->next)
+            ;
         r->next = route->next;
         route->next = routes[i];
         routes[i] = route;
@@ -796,11 +796,10 @@ update_neighbour_metric(struct neighbour *neigh, int changed)
 
         unsigned int cost = neighbour_cost(neigh);
         for(i = 0; i < route_slots; i++) {
-            struct babel_route *r = routes[i];
-            while(r) {
+            struct babel_route *r;
+            for(r = routes[i]; r; r = r->next) {
                 if(r->neigh == neigh)
                     update_route_metric(r, neigh, cost);
-                r = r->next;
             }
         }
     }
@@ -814,11 +813,10 @@ update_interface_metric(struct interface *ifp)
     int i;
 
     for(i = 0; i < route_slots; i++) {
-        struct babel_route *r = routes[i];
-        while(r) {
+        struct babel_route *r;
+        for(r = routes[i]; r; r = r->next) {
             if(r->neigh->ifp == ifp)
                 update_route_metric(r, r->neigh, neighbour_cost(r->neigh));
-            r = r->next;
         }
     }
 }
@@ -1066,8 +1064,8 @@ retract_neighbour_routes(struct neighbour *neigh)
     int i;
 
     for(i = 0; i < route_slots; i++) {
-        struct babel_route *r = routes[i];
-        while(r) {
+        struct babel_route *r;
+        for(r = routes[i]; r; r = r->next) {
             if(r->neigh == neigh) {
                 if(r->refmetric != INFINITY) {
                     unsigned short oldmetric = route_metric(r);
@@ -1076,7 +1074,6 @@ retract_neighbour_routes(struct neighbour *neigh)
                         route_changed(r, r->src, oldmetric);
                 }
             }
-            r = r->next;
         }
     }
 }

--- a/net/babel/files/route.h
+++ b/net/babel/files/route.h
@@ -96,7 +96,7 @@ struct babel_route *install_best_route(const unsigned char prefix[16],
                                  unsigned char plen);
 void update_neighbour_metric(struct neighbour *neigh, int changed);
 void update_interface_metric(struct interface *ifp);
-void update_route_metric(struct babel_route *route);
+void update_route_metric(struct babel_route *route, struct neighbour *neigh, unsigned int cost);
 struct babel_route *update_route(const unsigned char *id,
                                  const unsigned char *prefix, unsigned char plen,
                                  const unsigned char *src_prefix,


### PR DESCRIPTION
Babel supernodes can easily have 100,000 route entries they need to manage, so optimize updating them as much as possible.