### PR TITLE
Babel faster neighbor check and update

### DIFF
--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -38,6 +38,7 @@ THE SOFTWARE.
 #include "message.h"
 #include "resend.h"
 #include "local.h"
+#include "configuration.h"
 
 struct neighbour *neighs = NULL;
 
@@ -246,7 +247,7 @@ check_neighbours()
         else {
             changed = reset_txcost(neigh) || changed;
             /* Temp cost to avoid recalculating later */
-            neigh->temp_cost = changed ? (int)neighbour_cost(neigh) : -1;
+            neigh->temp_cost = (int)neighbour_cost(neigh);
 
             anychanged |= changed;
 
@@ -263,18 +264,42 @@ check_neighbours()
     if (anychanged) {
         for(i = 0; i < route_slots; i++) {
             struct babel_route *r;
+            struct babel_route *installed = NULL;
+            struct babel_route *best = NULL;
+            unsigned int installed_oldmetric = INFINITY;
             for(r = routes[i]; r; r = r->next) {
                 struct neighbour *n = r->neigh;
-                int temp_cost = n->temp_cost;
-                if (temp_cost >= 0)
-                    update_route_metric(r, n, temp_cost);
+                int oldmetric = route_metric(r);
+                if(r->time < now.tv_sec - r->hold_time) { // route_expired
+                    if(r->refmetric < INFINITY) {
+                        r->seqno = seqno_plus(r->src->seqno, 1);
+                        change_route_metric(r, INFINITY, INFINITY, 0); // retract_route
+                    }
+                } else {
+                    int add_metric = input_filter(r->src->id,
+                                                r->src->prefix, r->src->plen,
+                                                r->src->src_prefix,
+                                                r->src->src_plen,
+                                                n->address,
+                                                n->ifp->ifindex);
+                    change_route_metric(r, r->refmetric, n->temp_cost, add_metric);
+                    if (route_feasible(r) && (!best || r->smoothed_metric < best->smoothed_metric))
+                        best = r;
+                }
+                if (r->installed && route_metric(r) < INFINITY) {
+                    installed = r;
+                    installed_oldmetric = oldmetric;
+                }
             }
+            if (best && best != installed)
+                consider_route(best);
+            else if (installed)
+                send_triggered_update(installed, installed->src, installed_oldmetric);
         }
 
-        for(neigh = neighs; neigh; neigh = neigh->next) {
+        for(neigh = neighs; neigh; neigh = neigh->next)
             if (neigh->temp_cost >= 0)
                 local_notify_neighbour(neigh, LOCAL_CHANGE);
-        }
     }
 
     return msecs;

--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -247,7 +247,7 @@ check_neighbours()
         else {
             changed = reset_txcost(neigh) || changed;
             /* Temp cost to avoid recalculating later */
-            neigh->temp_cost = (int)neighbour_cost(neigh);
+            neigh->temp_cost = changed ? (int)neighbour_cost(neigh) : -1;
 
             anychanged |= changed;
 
@@ -272,7 +272,11 @@ check_neighbours()
                 struct neighbour *n = r->neigh;
                 int old_metric = route_metric(r);
                 int old_smoothed_metric = route_smoothed_metric(r);
-                if(r->time < now.tv_sec - r->hold_time) { // route_expired
+                if (n->temp_cost < 0) {
+                    if (route_feasible(r) && (!best || old_smoothed_metric < best->smoothed_metric))
+                        best = r;
+                }
+                else if(r->time < now.tv_sec - r->hold_time) { // route_expired
                     if(r->refmetric < INFINITY) {
                         r->seqno = seqno_plus(r->src->seqno, 1);
                         change_route_metric(r, INFINITY, INFINITY, 0); // retract_route
@@ -288,7 +292,7 @@ check_neighbours()
                     if (route_feasible(r) && (!best || r->smoothed_metric < best->smoothed_metric))
                         best = r;
                 }
-                if (r->installed && route_metric(r) < INFINITY) {
+                if (r->installed) {
                     installed = r;
                     installed_oldmetric = old_metric;
                     installed_smoothed_metrict = old_smoothed_metric;

--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -267,9 +267,11 @@ check_neighbours()
             struct babel_route *installed = NULL;
             struct babel_route *best = NULL;
             unsigned int installed_oldmetric = INFINITY;
+            unsigned int installed_smoothed_metrict = INFINITY;
             for(r = routes[i]; r; r = r->next) {
                 struct neighbour *n = r->neigh;
-                int oldmetric = route_metric(r);
+                int old_metric = route_metric(r);
+                int old_smoothed_metric = route_smoothed_metric(r);
                 if(r->time < now.tv_sec - r->hold_time) { // route_expired
                     if(r->refmetric < INFINITY) {
                         r->seqno = seqno_plus(r->src->seqno, 1);
@@ -288,12 +290,13 @@ check_neighbours()
                 }
                 if (r->installed && route_metric(r) < INFINITY) {
                     installed = r;
-                    installed_oldmetric = oldmetric;
+                    installed_oldmetric = old_metric;
+                    installed_smoothed_metrict = old_smoothed_metric;
                 }
             }
             if (best && best != installed)
                 consider_route(best);
-            else if (installed)
+            else if (installed && installed_oldmetric != route_metric(installed) && installed_smoothed_metrict != installed->smoothed_metric)
                 send_triggered_update(installed, installed->src, installed_oldmetric);
         }
 


### PR DESCRIPTION
Unroll the neighbor check function to optimize it as much as possible. This was struggling with supernode where it was scanning 1,000,000 route entries (different from routes which is a smaller number) on supernodes with many connections. This is not the only bottleneck when scaling to these large numbers. More to do.