### PR TITLE
Revert optimized check_neighbour function

### DIFF
--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -282,7 +282,6 @@ check_neighbours()
                     route->src->src_prefix, route->src->src_plen, 1, NULL);
             if(better_route && route_metric(better_route) < route_metric(route))
                 consider_route(better_route);
-            }
         }
     }
 

--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -223,7 +223,7 @@ neighbour_txcost(struct neighbour *neigh)
     return neigh->txcost;
 }
 
-#if 1
+#if 0
 unsigned
 check_neighbours()
 {

--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -274,6 +274,18 @@ check_neighbours()
         }
     }
 
+    for(i = 0; i < route_slots; i++) {
+        struct babel_route *route = routes[i];
+        if (route) {
+            struct babel_route *better_route =
+                find_best_route(route->src->prefix, route->src->plen,
+                    route->src->src_prefix, route->src->src_plen, 1, NULL);
+            if(better_route && route_metric(better_route) < route_metric(route))
+                consider_route(better_route);
+            }
+        }
+    }
+
     for(neigh = neighs; neigh; neigh = neigh->next)
         local_notify_neighbour(neigh, LOCAL_CHANGE);
 

--- a/net/babel/files/neighbour.c
+++ b/net/babel/files/neighbour.c
@@ -223,74 +223,6 @@ neighbour_txcost(struct neighbour *neigh)
     return neigh->txcost;
 }
 
-#if 0
-unsigned
-check_neighbours()
-{
-    struct neighbour *neigh;
-    struct neighbour *nneigh;
-    unsigned msecs = 50000;
-    int i;
-    int changes = 0;
-
-    debugf("Checking neighbours.\n");
-
-    for(neigh = neighs; neigh; neigh = nneigh) {
-        int changed;
-        nneigh = neigh->next;
-        changed = update_neighbour(neigh, &neigh->hello, 0, -1, 0);
-        changed = update_neighbour(neigh, &neigh->uhello, 1, -1, 0) || changed;
-
-        if(neigh->hello.reach == 0 ||
-           neigh->hello.time.tv_sec > now.tv_sec || /* clock stepped */
-           timeval_minus_msec(&now, &neigh->hello.time) > 300000) {
-            flush_neighbour(neigh);
-        }
-        else {
-            changed = reset_txcost(neigh) || changed;
-            /* Temp cost to avoid recalculating later */
-            neigh->temp_cost = changed ? (unsigned short)neighbour_cost(neigh) : (INFINITY + 1);
-
-            if(neigh->hello.interval > 0)
-                msecs = MIN(msecs, neigh->hello.interval * 10);
-            if(neigh->uhello.interval > 0)
-                msecs = MIN(msecs, neigh->uhello.interval * 10);
-            if(neigh->ihu_interval > 0)
-                msecs = MIN(msecs, neigh->ihu_interval * 10);
-
-            changes |= changed;
-        }
-    }
-
-    if (changes) {
-        for(i = 0; i < route_slots; i++) {
-            struct babel_route *r;
-            for(r = routes[i]; r; r = r->next) {
-                struct neighbour *neigh = r->neigh;
-                unsigned int temp_cost = neigh->temp_cost;
-                if (temp_cost <= INFINITY)
-                    update_route_metric(r, neigh, temp_cost);
-            }
-        }
-    }
-
-    for(i = 0; i < route_slots; i++) {
-        struct babel_route *route = routes[i];
-        if (route) {
-            struct babel_route *better_route =
-                find_best_route(route->src->prefix, route->src->plen,
-                    route->src->src_prefix, route->src->src_plen, 1, NULL);
-            if(better_route && route_metric(better_route) < route_metric(route))
-                consider_route(better_route);
-        }
-    }
-
-    for(neigh = neighs; neigh; neigh = neigh->next)
-        local_notify_neighbour(neigh, LOCAL_CHANGE);
-
-    return msecs;
-}
-#else
 unsigned
 check_neighbours()
 {
@@ -331,7 +263,6 @@ check_neighbours()
 
     return msecs;
 }
-#endif
 
 /* To lose one hello is a misfortune, to lose two is carelessness. */
 static int


### PR DESCRIPTION
Revert from optimized version of this function.
It just seems to work better despite it being much slower (too many loops nested).
Hopefully the reduction in supernode retransmission traffic is enough to make the need
to optimize this unnecessary.